### PR TITLE
feat: Add max polling retries to client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,11 @@ export default class TipccClient extends EventEmitter {
 
   private lastPoll = new Date();
 
+  /**
+   * Create a tip.cc client.
+   * @param token The tip.cc API token to use
+   * @param options Optional options
+   */
   constructor(
     token: string,
     options: {
@@ -76,6 +81,9 @@ export default class TipccClient extends EventEmitter {
     });
   }
 
+  /**
+   * Poll the tip.cc API for new data.
+   */
   private async _poll(): Promise<void> {
     const now = new Date();
     let transactions;
@@ -85,9 +93,9 @@ export default class TipccClient extends EventEmitter {
       try {
         transactions = (
           (await this.REST.request('GET', '/account/transactions', {
-        types: [...this.polling],
-        since: this.lastPoll.toISOString(),
-        until: now.toISOString(),
+            types: [...this.polling],
+            since: this.lastPoll.toISOString(),
+            until: now.toISOString(),
           })) as APIRESTGetAccountTransactions
         ).transactions;
 
@@ -140,6 +148,10 @@ export default class TipccClient extends EventEmitter {
     return this;
   }
 
+  /**
+   * Get a list of cryptocurrencies.
+   * @param cache Whether to use the cache (`true` by default)
+   */
   public async getCryptoCurrencies(cache = true): Promise<CryptoCurrency[]> {
     const currencies = getCachedCryptoCurrencies();
     if (currencies.length > 0 && cache) return currencies;
@@ -147,6 +159,10 @@ export default class TipccClient extends EventEmitter {
     return getCachedCryptoCurrencies();
   }
 
+  /**
+   * Get a list of fiat currencies.
+   * @param cache Whether to use the cache (`true` by default)
+   */
   public async getFiatCurrencies(cache = true): Promise<CryptoCurrency[]> {
     const currencies = getCachedCryptoCurrencies();
     if (currencies.length > 0 && cache) return currencies;
@@ -154,6 +170,10 @@ export default class TipccClient extends EventEmitter {
     return getCachedCryptoCurrencies();
   }
 
+  /**
+   * Get a list of transactions based on options.
+   * @param options Which options to use when requesting transactions
+   */
   public async getTransactions(
     options: {
       types?: string[];
@@ -171,6 +191,9 @@ export default class TipccClient extends EventEmitter {
     return transactions.map((t) => new Transaction(t));
   }
 
+  /**
+   * Get a list of exchange rates.
+   */
   public async getExchangeRates(): Promise<ExchangeRate[]> {
     const { rates } = (await this.REST.request(
       'GET',
@@ -179,6 +202,10 @@ export default class TipccClient extends EventEmitter {
     return rates.map((r) => new ExchangeRate(r));
   }
 
+  /**
+   * Get a single transaction.
+   * @param id The transaction id
+   */
   public async getTransaction(id: string): Promise<Transaction | null> {
     const { transaction } = (await this.REST.request(
       'GET',
@@ -188,6 +215,10 @@ export default class TipccClient extends EventEmitter {
     return new Transaction(transaction);
   }
 
+  /**
+   * Post a new tip.
+   * @param payload The post tip payload
+   */
   public async postTip(
     payload: APIRESTPostTipPayload,
   ): Promise<APIRESTPostTips> {
@@ -198,6 +229,11 @@ export default class TipccClient extends EventEmitter {
     )) as APIRESTPostTips;
   }
 
+  /**
+   * Get a single wallet.
+   * @param currency The wallet currency
+   * @param fallback Whether to create an empty wallet if there's no API response
+   */
   public async getWallet(
     currency: string,
     fallback = true,
@@ -223,6 +259,9 @@ export default class TipccClient extends EventEmitter {
     );
   }
 
+  /**
+   * Get all wallets.
+   */
   public async getWallets(): Promise<Wallet[]> {
     const { wallets } = (await this.REST.request(
       'GET',

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ export default class TipccClient extends EventEmitter {
     let transactions;
 
     // Retry until a successful reponse is received or max retries are reached
-    while (transactions === undefined) {
+    do {
       try {
         transactions = (
           (await this.REST.request('GET', '/account/transactions', {
@@ -108,7 +108,7 @@ export default class TipccClient extends EventEmitter {
             `Failed ${this.pollingRetries} consecutive API polls. Is the API responding?`,
           );
       }
-    }
+    } while(!transactions);
 
     // Reset pollingRetries, as it should only increment if multiple consecutive requests don't succeed
     if (this.pollingRetries > 0) this.pollingRetries = 0;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,6 @@
     "outDir": "./dist",
     "strict": true
   },
-  "include": ["src", ".eslintrc.js"],
+  "include": ["src/**/*", ".eslintrc.js"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This pull request:
- Adds a max number of polling retries to the client, and if all fail, an error will be thrown
This option is also customizable using the `options` argument when instantiating a client.
- Documents client with JSDocs
- Adds all files under `src` to tsconfig.json