### PR TITLE
feat(RequestHandler): Shortcuts for GET and POST

### DIFF
--- a/src/structures/RequestHandler.ts
+++ b/src/structures/RequestHandler.ts
@@ -59,6 +59,34 @@ export default class RequestHandler {
     }
   }
 
+  /**
+   * A shortcut for a GET request.
+   * @param route The route to request
+   * @param payload The data to send with the request
+   * @param requestOptions Optional additional configuration for Axios
+   */
+  public get(
+    route: string,
+    payload: any = {},
+    requestOptions: AxiosRequestConfig = {},
+  ) {
+    return this.request('GET', route, payload, requestOptions);
+  }
+
+  /**
+   * A shortcut for a POST request.
+   * @param route The route to request
+   * @param payload The data to send with the request
+   * @param requestOptions Optional additional configuration for Axios
+   */
+  public post(
+    route: string,
+    payload: any = {},
+    requestOptions: AxiosRequestConfig = {},
+  ) {
+    return this.request('POST', route, payload, requestOptions);
+  }
+
   public request(
     method: 'POST' | 'GET',
     route: string,


### PR DESCRIPTION
This adds shortcuts for GET and POST requests for `RequestHandler`, as these are the two types that can be used with `RequestHandler.request()`.
The `RequestHandler.request('GET')` and `RequestHandler.request('POST')` functionality is not affected by this PR.