### PR TITLE
fix: TypeScript exactOptionalPropertyTypes errors

### DIFF
--- a/src/structures/Amount.ts
+++ b/src/structures/Amount.ts
@@ -14,7 +14,7 @@ import FiatCurrency from './FiatCurrency';
 export default class Amount {
   public value: BigNumber;
 
-  public currency?: CryptoCurrency | FiatCurrency;
+  public currency: CryptoCurrency | FiatCurrency | null;
 
   /**
    * Create an Amount.
@@ -28,10 +28,10 @@ export default class Amount {
     this.value = BigNumber(payload.value);
     switch (currencyType) {
       case 'crypto':
-        this.currency = getCachedCryptoCurrency(payload.currency);
+        this.currency = getCachedCryptoCurrency(payload.currency) ?? null;
         break;
       case 'fiat':
-        this.currency = getCachedFiatCurrency(payload.currency);
+        this.currency = getCachedFiatCurrency(payload.currency) ?? null;
         break;
     }
   }

--- a/src/structures/CurrencyFormat.ts
+++ b/src/structures/CurrencyFormat.ts
@@ -1,4 +1,7 @@
-import { APICryptoCurrency, APIFiatCurrency } from '@tipccjs/tipcc-api-types';
+import type {
+  APICryptoCurrency,
+  APIFiatCurrency,
+} from '@tipccjs/tipcc-api-types';
 import CryptoCurrencyUnit from './CurrencyFormatUnits';
 
 /**

--- a/src/structures/CurrencyFormatUnits.ts
+++ b/src/structures/CurrencyFormatUnits.ts
@@ -9,21 +9,21 @@ import type {
 export default class CurrencyUnit {
   public singular: string;
 
-  public plural?: string;
+  public plural: string | null;
 
-  public prefix?: string;
+  public prefix: string | null;
 
-  public suffix?: string;
+  public suffix: string | null;
 
   public scale: number;
 
   public aliases: string[];
 
-  public minDecimals?: number;
+  public minDecimals: number | null;
 
-  public optionalDecimals?: boolean;
+  public optionalDecimals: boolean | null;
 
-  public min?: number;
+  public min: number | null;
 
   /**
    * Create a CryptoCurrencyUnit.
@@ -31,13 +31,13 @@ export default class CurrencyUnit {
    */
   constructor(payload: APIFiatCurrencyUnit | APICryptoCurrencyUnit) {
     this.singular = payload.singular;
-    this.plural = payload.plural ?? undefined;
-    this.prefix = payload.prefix;
-    this.suffix = payload.suffix;
+    this.plural = payload.plural ?? null;
+    this.prefix = payload.prefix ?? null;
+    this.suffix = payload.suffix ?? null;
     this.scale = payload.scale;
     this.aliases = payload.aliases ?? [];
-    this.minDecimals = payload.minDecimals;
-    this.optionalDecimals = payload.optionalDecimals;
-    this.min = payload.min;
+    this.minDecimals = payload.minDecimals ?? null;
+    this.optionalDecimals = payload.optionalDecimals ?? null;
+    this.min = payload.min ?? null;
   }
 }

--- a/src/structures/RequestHandler.ts
+++ b/src/structures/RequestHandler.ts
@@ -23,7 +23,7 @@ export default class RequestHandler {
   constructor(
     apiKey: string,
     payload: {
-      apiBaseUrl?: string;
+      apiBaseUrl?: string | undefined;
     } = {},
   ) {
     this._apiBaseUrl = payload.apiBaseUrl ?? 'https://api.tip.cc/api/v0';

--- a/src/structures/User.ts
+++ b/src/structures/User.ts
@@ -6,9 +6,9 @@ import type { APIConnection } from '@tipccjs/tipcc-api-types';
 export default class User {
   public identifier: string;
 
-  public username?: string;
+  public username: string | null;
 
-  public avatarUrl?: string;
+  public avatarUrl: string | null;
 
   public service: 'discord';
 
@@ -18,8 +18,8 @@ export default class User {
    */
   constructor(payload: APIConnection) {
     this.identifier = payload.identifier;
-    this.username = payload.username;
-    this.avatarUrl = payload.avatar_url;
+    this.username = payload.username ?? null;
+    this.avatarUrl = payload.avatar_url ?? null;
     this.service = payload.service;
   }
 }

--- a/src/structures/Wallet.ts
+++ b/src/structures/Wallet.ts
@@ -1,4 +1,4 @@
-import { APIWallet } from '@tipccjs/tipcc-api-types';
+import type { APIWallet } from '@tipccjs/tipcc-api-types';
 import Amount from './Amount';
 
 /**

--- a/src/utils/CacheHandler.ts
+++ b/src/utils/CacheHandler.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   RESTGetAPICurrenciesCryptoCurrenciesResult,
   RESTGetAPICurrenciesFiatsResult,
 } from '@tipccjs/tipcc-api-types';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "removeComments": false,
     "strictNullChecks": true,
     "preserveConstEnums": true,
+    "exactOptionalPropertyTypes": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true
   },


### PR DESCRIPTION
This PR addresses multiple TypeScript errors.
These are caused by `exactOptionalPropertyTypes`, as enabled in #12.
Most of the time `null` was preferred over `undefined`, as structures always had properties, but they could be `null`.