### PR TITLE
feat: Move currency caches to own classes

### DIFF
--- a/src/structures/TipccClient.ts
+++ b/src/structures/TipccClient.ts
@@ -5,12 +5,6 @@ import {
   ExchangeRateCache,
   FiatCache,
 } from './CurrencyCache';
-import { ExchangeRate } from './ExchangeRate';
-
-import {
-  RESTGetAPICurrenciesRatesResult,
-  Routes,
-} from '@tipccjs/tipcc-api-types/v0';
 import { WalletManager } from './Manager/WalletManager';
 import { TransactionManager } from './Manager/TransactionManager';
 


### PR DESCRIPTION
This fixes a bug caused by using separate refresh functions in CurrencyCache.