### PR TITLE
build: Prepare package for publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ dist
 /docs
 /lib
 test.*
+/.vscode

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Walledgarden
+Copyright (c) 2023 tipcc.js contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tipcc.js",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tipcc.js",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "ISC",
       "dependencies": {
         "@mxssfd/typedoc-theme": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,14 @@
 {
   "name": "tipcc.js",
   "version": "0.0.2",
-  "description": "# tip.cc API Client",
+  "description": "tip.cc API Client",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
   "files": [
     "lib/**/*",
-    "LICENSE",
     "README.md",
-    "package.json",
-    "tsconfig.json",
-    "package-lock.json"
+    "LICENSE",
+    "package.json"
   ],
   "scripts": {
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --fix",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,34 @@
     "LICENSE",
     "package.json"
   ],
+  "homepage": "https://tipccjs.org/",
+  "bugs": {
+    "url": "https://github.com/tipccjs/tipcc.js/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tipccjs/tipcc.js"
+  },
+  "keywords": [
+    "tip.cc",
+    "tipcc",
+    "tipcc.js",
+    "tipccjs",
+    "tipcc-api",
+    "tipcc-client",
+    "tipcc-api-client"
+  ],
+  "contributors": [
+    {
+      "name": "Walledgarden",
+      "url": "https://github.com/Walledgarden"
+    },
+    {
+      "name": "ZeroWave",
+      "url": "https://github.com/ZeroWave022"
+    }
+  ],
   "scripts": {
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "prettify": "prettier --write .",
@@ -19,9 +47,6 @@
     "build": "tsc",
     "build:docs": "typedoc"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.57.0",
     "@typescript-eslint/parser": "^5.57.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,5 @@
     "lib": ["ES2022"],
     "forceConsistentCasingInFileNames": true
   },
-  "exclude": ["node_modules", "docs", "lib"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
This PR changes configuration files so they are prepared for a 1.0.0 launch of the package.
Also makes the copyright to the library apply to contributors.