### PR TITLE
feat: Add retry interval to TransactionManager

### DIFF
--- a/src/structures/TipccClient.ts
+++ b/src/structures/TipccClient.ts
@@ -46,6 +46,9 @@ export class TipccClient extends EventEmitter {
   /** The number of milliseconds between each API poll  */
   public pollingInterval = 10000;
 
+  /** The number of milliseconds to wait before retrying an API poll */
+  public retryInterval = 2000;
+
   /** The max number of retries to poll the API, after which an error will be thrown */
   public maxRetries = 5;
 
@@ -60,6 +63,7 @@ export class TipccClient extends EventEmitter {
    * @param options The options to use
    * @param options.baseUrl The base URL for requests
    * @param options.pollingInterval The number of milliseconds between each API poll. Defaults to `10000`.
+   * @param options.retryInterval The number of milliseconds to wait before retrying an API poll. Defaults to `2000`.
    * @param options.maxRetries The max number of retries to poll the API, after which an error will be thrown. Defaults to `5`.
    */
   constructor(
@@ -67,6 +71,7 @@ export class TipccClient extends EventEmitter {
     options: {
       baseUrl?: string;
       pollingInterval?: number;
+      retryInterval?: number;
       maxRetries?: number;
     } = {},
   ) {
@@ -85,6 +90,7 @@ export class TipccClient extends EventEmitter {
     });
 
     if (options.pollingInterval) this.pollingInterval = options.pollingInterval;
+    if (options.retryInterval) this.retryInterval = options.retryInterval;
     if (options.maxRetries) this.maxRetries = options.maxRetries;
 
     this.wallets = new WalletManager({
@@ -94,6 +100,7 @@ export class TipccClient extends EventEmitter {
       client: this,
       pollingInterval: this.pollingInterval,
       maxPollingRetries: this.maxRetries,
+      retryInterval: this.retryInterval,
     });
 
     this._init();

--- a/src/structures/TipccClient.ts
+++ b/src/structures/TipccClient.ts
@@ -75,12 +75,6 @@ export class TipccClient extends EventEmitter {
     if (!/(^[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*$)/.test(token))
       throw new Error('Invalid token provided');
 
-    this.wallets = new WalletManager({
-      client: this,
-    });
-    this.transactions = new TransactionManager({
-      client: this,
-    });
     this.cryptos = new CryptocurrencyCache(this);
     this.fiats = new FiatCache(this);
     this.exchangeRates = new ExchangeRateCache(this);
@@ -92,6 +86,15 @@ export class TipccClient extends EventEmitter {
 
     if (options.pollingInterval) this.pollingInterval = options.pollingInterval;
     if (options.maxRetries) this.maxRetries = options.maxRetries;
+
+    this.wallets = new WalletManager({
+      client: this,
+    });
+    this.transactions = new TransactionManager({
+      client: this,
+      pollingInterval: this.pollingInterval,
+      maxPollingRetries: this.maxRetries,
+    });
 
     this._init();
   }


### PR DESCRIPTION
This fixes an issue where TransactionManager will retry an API poll too fast. The issue is described [here](https://discord.com/channels/1076928670096183406/1076931034458898552/1274031439670673450).

This PR adds a retry interval, and allows it to be set on the TipccClient, which will in turn pass it down to TransactionManager during it's instantiation.

The polling interval and max retries weren't passed down to TransactionManager, however, this PR fixes this too.
